### PR TITLE
[WIP] 리스트 검색/필터링 기능 추가

### DIFF
--- a/bin/main/mapper/TodoMapper.xml
+++ b/bin/main/mapper/TodoMapper.xml
@@ -3,6 +3,33 @@
     "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="org.zerock.springex.mapper.TodoMapper">
+	<!-- 재사용 SQL -->
+	<sql id="listSearch">
+		<where>
+			<if test="types != null and types.length > 0 and keyword != null and keyword != ''">
+				<foreach collection="types" item="type" open="(" separator=" or " close=")">
+					<if test="type == 't'.toString()">
+						title like concat('%',#{keyword},'%')
+					</if>
+					<if test="type == 'w'.toString()">
+						writer like concat('%',#{keyword},'%')
+					</if>
+				</foreach>
+			</if>
+			<if test="finished != null">
+				<trim prefix="and">
+					finished = #{finished}
+				</trim>
+			</if>
+
+			<if test="from != null and to != null">
+				<trim prefix="and">
+					dueDate BETWEEN #{from} AND #{to}
+				</trim>
+			</if>
+		</where>
+	</sql>
+
 	<select id="getTime" resultType="String">
 		select now()
 	</select>
@@ -36,7 +63,8 @@
 		parameterType="org.zerock.springex.domain.TodoVO">
 		update tbl_todo
 		set title = #{title}
-		, dueDate = #{dueDate}
+		, dueDate =
+		#{dueDate}
 		, finished = #{finished}
 		where tno = #{tno}
 	</update>
@@ -44,17 +72,7 @@
 	<select id="selectList"
 		resultType="org.zerock.springex.domain.TodoVO">
 		select tno, title, dueDate, writer, finished from tbl_todo
-
-		<where>
-			<foreach collection="types" item="type" separator="or">
-				<if test="type == 't'.toString()">
-					title like concat('%',#{keyword},'%')
-				</if>
-				<if test="type == 'w'.toString()">
-					writer like concat('%',#{keyword},'%')
-				</if>
-			</foreach>
-		</where>
+		<include refid="listSearch" />
 		order by tno desc limit #{skip},#{size}
 	</select>
 

--- a/bin/main/mapper/TodoMapper.xml
+++ b/bin/main/mapper/TodoMapper.xml
@@ -78,5 +78,6 @@
 
 	<select id="getCount" resultType="int">
 		select count(*) from tbl_todo
+		<include refid="listSearch" />
 	</select>
 </mapper>

--- a/bin/main/mapper/TodoMapper.xml
+++ b/bin/main/mapper/TodoMapper.xml
@@ -19,7 +19,7 @@
 		select tno, title, dueDate, writer, finished
 		from tbl_todo
 		order by tno desc;
-	</select>	
+	</select>
 
 	<select id="selectOne"
 		resultType="org.zerock.springex.domain.TodoVO">
@@ -27,23 +27,37 @@
 		from tbl_todo
 		where tno = #{tno}
 	</select>
-	
+
 	<delete id="delete">
 		delete from tbl_todo where tno = #{tno}
 	</delete>
-	
-	<update id="update" parameterType="org.zerock.springex.domain.TodoVO">
+
+	<update id="update"
+		parameterType="org.zerock.springex.domain.TodoVO">
 		update tbl_todo
-		   set title = #{title}
-		     , dueDate = #{dueDate}
-		     , finished = #{finished}
-		 where tno = #{tno} 
+		set title = #{title}
+		, dueDate = #{dueDate}
+		, finished = #{finished}
+		where tno = #{tno}
 	</update>
-	
-	<select id="selectList" resultType="org.zerock.springex.domain.TodoVO">
-		select tno, title, dueDate, writer, finished from tbl_todo order by tno desc limit #{skip},#{size}
+
+	<select id="selectList"
+		resultType="org.zerock.springex.domain.TodoVO">
+		select tno, title, dueDate, writer, finished from tbl_todo
+
+		<where>
+			<foreach collection="types" item="type" separator="or">
+				<if test="type == 't'.toString()">
+					title like concat('%',#{keyword},'%')
+				</if>
+				<if test="type == 'w'.toString()">
+					writer like concat('%',#{keyword},'%')
+				</if>
+			</foreach>
+		</where>
+		order by tno desc limit #{skip},#{size}
 	</select>
-	
+
 	<select id="getCount" resultType="int">
 		select count(*) from tbl_todo
 	</select>

--- a/src/main/java/org/zerock/springex/dto/PageRequestDTO.java
+++ b/src/main/java/org/zerock/springex/dto/PageRequestDTO.java
@@ -1,6 +1,9 @@
 package org.zerock.springex.dto;
 
 import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
@@ -47,6 +50,27 @@ public class PageRequestDTO {
 			StringBuilder builder = new StringBuilder();
 			builder.append("page=" + this.page);
 			builder.append("&size=" + this.size);
+			
+			if(types != null && types.length > 0) {
+				String type = Arrays.stream(types)
+						.filter(Objects::nonNull)
+						.map(t->"&value="+t)
+						.collect(Collectors.joining());
+				
+				builder.append(type);
+			}
+			
+			if(keyword != null) {
+				builder.append("&keyword=" + this.keyword);
+			}
+			
+			builder.append("&finished=" + this.finished);
+			
+			if(from != null && to != null) {
+				builder.append("&from=" + this.from);
+				builder.append("&to=" + this.to);
+			}
+			
 			link = builder.toString();
 		}
 		

--- a/src/main/java/org/zerock/springex/dto/PageRequestDTO.java
+++ b/src/main/java/org/zerock/springex/dto/PageRequestDTO.java
@@ -50,30 +50,43 @@ public class PageRequestDTO {
 			StringBuilder builder = new StringBuilder();
 			builder.append("page=" + this.page);
 			builder.append("&size=" + this.size);
-			
-			if(types != null && types.length > 0) {
-				String type = Arrays.stream(types)
-						.filter(Objects::nonNull)
-						.map(t->"&value="+t)
-						.collect(Collectors.joining());
-				
-				builder.append(type);
-			}
-			
-			if(keyword != null) {
-				builder.append("&keyword=" + this.keyword);
-			}
-			
-			builder.append("&finished=" + this.finished);
-			
-			if(from != null && to != null) {
-				builder.append("&from=" + this.from);
-				builder.append("&to=" + this.to);
-			}
-			
 			link = builder.toString();
 		}
 		
+		StringBuilder builder = new StringBuilder();
+		builder.append("&finished=" + this.finished);
+		link += builder.toString();
+		
+		if(types != null && types.length > 0) {
+			String type = Arrays.stream(types)
+					.filter(Objects::nonNull)
+					.map(t->"&types="+t)
+					.collect(Collectors.joining());
+			
+			builder.append(type);
+			link += builder.toString();
+		}
+		
+		if(keyword != null) {
+			builder.append("&keyword=" + this.keyword);
+			link += builder.toString();
+		}
+		
+		if(from != null && to != null) {
+			builder.append("&from=" + this.from);
+			builder.append("&to=" + this.to);
+			link += builder.toString();
+		}
+		
 		return link;
+	}
+	
+	public boolean checkType(String type) {
+		
+		if(types == null || types.length == 0) {
+			return false;
+		}
+		
+		return Arrays.stream(types).anyMatch(type::equals);
 	}
 }

--- a/src/main/java/org/zerock/springex/dto/PageRequestDTO.java
+++ b/src/main/java/org/zerock/springex/dto/PageRequestDTO.java
@@ -1,5 +1,7 @@
 package org.zerock.springex.dto;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
 import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.Objects;
@@ -46,39 +48,40 @@ public class PageRequestDTO {
 	}
 	
 	public String getLink() {
-		if(link == null) {
-			StringBuilder builder = new StringBuilder();
-			builder.append("page=" + this.page);
-			builder.append("&size=" + this.size);
-			link = builder.toString();
+		StringBuilder builder = new StringBuilder();
+		
+		builder.append("page=" + this.page);
+		builder.append("&size=" + this.size);
+		
+		if(finished) {
+			builder.append("&finished=on");
 		}
 		
-		StringBuilder builder = new StringBuilder();
-		builder.append("&finished=" + this.finished);
-		link += builder.toString();
-		
 		if(types != null && types.length > 0) {
-			String type = Arrays.stream(types)
-					.filter(Objects::nonNull)
-					.map(t->"&types="+t)
-					.collect(Collectors.joining());
-			
-			builder.append(type);
-			link += builder.toString();
+			for(int i = 0; i < types.length; i++) {
+				builder.append("&types=" + types[i]);
+			}
 		}
 		
 		if(keyword != null) {
-			builder.append("&keyword=" + this.keyword);
-			link += builder.toString();
+			try {
+				// 한글 깨짐 처리
+				builder.append("&keyword=" + URLEncoder.encode(keyword,"UTF-8"));
+			} catch (UnsupportedEncodingException e) {
+				// TODO Auto-generated catch block
+				e.printStackTrace();
+			}
 		}
 		
-		if(from != null && to != null) {
-			builder.append("&from=" + this.from);
-			builder.append("&to=" + this.to);
-			link += builder.toString();
+		if(from != null) {
+			builder.append("&from=" + from.toString());
 		}
 		
-		return link;
+		if(to != null) {
+			builder.append("&to=" + to.toString());
+		}
+		
+		return builder.toString();
 	}
 	
 	public boolean checkType(String type) {

--- a/src/main/java/org/zerock/springex/dto/PageRequestDTO.java
+++ b/src/main/java/org/zerock/springex/dto/PageRequestDTO.java
@@ -1,5 +1,7 @@
 package org.zerock.springex.dto;
 
+import java.time.LocalDate;
+
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.Positive;
@@ -26,6 +28,13 @@ public class PageRequestDTO {
 	@Positive
 	private int size = 10; // 한페이지에 보여줄 게시물 수
 	private int totalCount; // 전체 게시물 수
+	
+	// 검색 필터링 관련
+	private String[] types; // t:제목,w:작가
+	private String keyword; // 검색어
+	private boolean finished; // todo완료여부
+	private LocalDate from; // 기간
+	private LocalDate to; // 기간
 	
 	private String link;
 	

--- a/src/main/resources/mapper/TodoMapper.xml
+++ b/src/main/resources/mapper/TodoMapper.xml
@@ -3,6 +3,33 @@
     "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="org.zerock.springex.mapper.TodoMapper">
+	<!-- 재사용 SQL -->
+	<sql id="listSearch">
+		<where>
+			<if test="types != null and types.length > 0 and keyword != null and keyword != ''">
+				<foreach collection="types" item="type" open="(" separator=" or " close=")">
+					<if test="type == 't'.toString()">
+						title like concat('%',#{keyword},'%')
+					</if>
+					<if test="type == 'w'.toString()">
+						writer like concat('%',#{keyword},'%')
+					</if>
+				</foreach>
+			</if>
+			<if test="finished != null">
+				<trim prefix="and">
+					finished = #{finished}
+				</trim>
+			</if>
+
+			<if test="from != null and to != null">
+				<trim prefix="and">
+					dueDate BETWEEN #{from} AND #{to}
+				</trim>
+			</if>
+		</where>
+	</sql>
+
 	<select id="getTime" resultType="String">
 		select now()
 	</select>
@@ -36,7 +63,8 @@
 		parameterType="org.zerock.springex.domain.TodoVO">
 		update tbl_todo
 		set title = #{title}
-		, dueDate = #{dueDate}
+		, dueDate =
+		#{dueDate}
 		, finished = #{finished}
 		where tno = #{tno}
 	</update>
@@ -44,17 +72,7 @@
 	<select id="selectList"
 		resultType="org.zerock.springex.domain.TodoVO">
 		select tno, title, dueDate, writer, finished from tbl_todo
-
-		<where>
-			<foreach collection="types" item="type" separator="or">
-				<if test="type == 't'.toString()">
-					title like concat('%',#{keyword},'%')
-				</if>
-				<if test="type == 'w'.toString()">
-					writer like concat('%',#{keyword},'%')
-				</if>
-			</foreach>
-		</where>
+		<include refid="listSearch" />
 		order by tno desc limit #{skip},#{size}
 	</select>
 

--- a/src/main/resources/mapper/TodoMapper.xml
+++ b/src/main/resources/mapper/TodoMapper.xml
@@ -78,5 +78,6 @@
 
 	<select id="getCount" resultType="int">
 		select count(*) from tbl_todo
+		<include refid="listSearch" />
 	</select>
 </mapper>

--- a/src/main/resources/mapper/TodoMapper.xml
+++ b/src/main/resources/mapper/TodoMapper.xml
@@ -19,7 +19,7 @@
 		select tno, title, dueDate, writer, finished
 		from tbl_todo
 		order by tno desc;
-	</select>	
+	</select>
 
 	<select id="selectOne"
 		resultType="org.zerock.springex.domain.TodoVO">
@@ -27,23 +27,37 @@
 		from tbl_todo
 		where tno = #{tno}
 	</select>
-	
+
 	<delete id="delete">
 		delete from tbl_todo where tno = #{tno}
 	</delete>
-	
-	<update id="update" parameterType="org.zerock.springex.domain.TodoVO">
+
+	<update id="update"
+		parameterType="org.zerock.springex.domain.TodoVO">
 		update tbl_todo
-		   set title = #{title}
-		     , dueDate = #{dueDate}
-		     , finished = #{finished}
-		 where tno = #{tno} 
+		set title = #{title}
+		, dueDate = #{dueDate}
+		, finished = #{finished}
+		where tno = #{tno}
 	</update>
-	
-	<select id="selectList" resultType="org.zerock.springex.domain.TodoVO">
-		select tno, title, dueDate, writer, finished from tbl_todo order by tno desc limit #{skip},#{size}
+
+	<select id="selectList"
+		resultType="org.zerock.springex.domain.TodoVO">
+		select tno, title, dueDate, writer, finished from tbl_todo
+
+		<where>
+			<foreach collection="types" item="type" separator="or">
+				<if test="type == 't'.toString()">
+					title like concat('%',#{keyword},'%')
+				</if>
+				<if test="type == 'w'.toString()">
+					writer like concat('%',#{keyword},'%')
+				</if>
+			</foreach>
+		</where>
+		order by tno desc limit #{skip},#{size}
 	</select>
-	
+
 	<select id="getCount" resultType="int">
 		select count(*) from tbl_todo
 	</select>

--- a/src/main/webapp/WEB-INF/views/todo/list.jsp
+++ b/src/main/webapp/WEB-INF/views/todo/list.jsp
@@ -61,44 +61,40 @@
 							<div class="col-12">
 								<div class="form-check form-switch">
 									<input class="form-check-input" type="checkbox"
-										name="finished" value="true" ${param.finished ? 'checked' : ''}><label
+										name="finished" ${pageRequestDTO.finished ? 'checked' : ''}><label
 										class="form-check-label" for="finished"> 완료여부</label>
 								</div>
 							</div>
 
 							<!-- 검색 타입 & 키워드 -->
-							<c:forEach var="val" items="${paramValues.types}">
-								<c:if test="${val == 't'}"><c:set var="titleChecked" value="checked"/></c:if>
-								<c:if test="${val == 'w'}"><c:set var="writerChecked" value="checked"/></c:if>
-							</c:forEach>
 							<div class="col-12 col-md-6">
 								<label class="form-label d-block mb-2">검색 대상</label>
 								<div class="form-check form-check-inline">
 									<input class="form-check-input" type="checkbox"
-										name="types" value="t" ${titleChecked} > <label
+										name="types" value="t" ${pageRequestDTO.checkType('t') ? 'checked' : ''} > <label
 										class="form-check-label" for="typeTitle">제목</label>
 								</div>
 								<div class="form-check form-check-inline">
 									<input class="form-check-input" type="checkbox"
-										name="types" value="w" ${writerChecked}> <label
+										name="types" value="w" ${pageRequestDTO.checkType('w') ? 'checked' : ''}> <label
 										class="form-check-label" for="typeWriter">작성자</label>
 								</div>
 							</div>
 
 							<div class="col-12 col-md-6">
 								<label for="keyword" class="form-label">키워드</label> <input
-									type="text" name="keyword" value="${param.keyword}" class="form-control"
+									type="text" name="keyword" value="${pageRequestDTO.keyword}" class="form-control"
 									placeholder="검색어를 입력하세요">
 							</div>
 
 							<!-- 날짜 구간 -->
 							<div class="col-12 col-md-6">
 								<label for="from" class="form-label">시작 날짜</label> <input
-									type="date" name="from" value="${param.from}" class="form-control">
+									type="date" name="from" value="${pageRequestDTO.from}" class="form-control">
 							</div>
 							<div class="col-12 col-md-6">
 								<label for="to" class="form-label">종료 날짜</label> <input
-									type="date" name="to" value="${param.to}" class="form-control">
+									type="date" name="to" value="${pageRequestDTO.to}" class="form-control">
 							</div>
 
 							<!-- 버튼 -->

--- a/src/main/webapp/WEB-INF/views/todo/list.jsp
+++ b/src/main/webapp/WEB-INF/views/todo/list.jsp
@@ -41,8 +41,8 @@
 				</nav>
 			</div>
 		</div>
-<!-- 모든 파라미터 출력 -->
-<!-- 
+		<!-- 모든 파라미터 출력 -->
+		<!-- 
 <c:forEach var="p" items="${paramValues}">
     <p>${p.key} = ${p.value[0]}</p>
 </c:forEach>
@@ -60,8 +60,8 @@
 							<!-- 완료 여부 -->
 							<div class="col-12">
 								<div class="form-check form-switch">
-									<input class="form-check-input" type="checkbox"
-										name="finished" ${pageRequestDTO.finished ? 'checked' : ''}><label
+									<input class="form-check-input" type="checkbox" name="finished"
+										${pageRequestDTO.finished ? 'checked' : ''}><label
 										class="form-check-label" for="finished"> 완료여부</label>
 								</div>
 							</div>
@@ -70,37 +70,39 @@
 							<div class="col-12 col-md-6">
 								<label class="form-label d-block mb-2">검색 대상</label>
 								<div class="form-check form-check-inline">
-									<input class="form-check-input" type="checkbox"
-										name="types" value="t" ${pageRequestDTO.checkType('t') ? 'checked' : ''} > <label
-										class="form-check-label" for="typeTitle">제목</label>
+									<input class="form-check-input" type="checkbox" name="types"
+										value="t" ${pageRequestDTO.checkType('t') ? 'checked' : ''}>
+									<label class="form-check-label" for="typeTitle">제목</label>
 								</div>
 								<div class="form-check form-check-inline">
-									<input class="form-check-input" type="checkbox"
-										name="types" value="w" ${pageRequestDTO.checkType('w') ? 'checked' : ''}> <label
-										class="form-check-label" for="typeWriter">작성자</label>
+									<input class="form-check-input" type="checkbox" name="types"
+										value="w" ${pageRequestDTO.checkType('w') ? 'checked' : ''}>
+									<label class="form-check-label" for="typeWriter">작성자</label>
 								</div>
 							</div>
 
 							<div class="col-12 col-md-6">
 								<label for="keyword" class="form-label">키워드</label> <input
-									type="text" name="keyword" value="${pageRequestDTO.keyword}" class="form-control"
-									placeholder="검색어를 입력하세요">
+									type="text" name="keyword" value="${pageRequestDTO.keyword}"
+									class="form-control" placeholder="검색어를 입력하세요">
 							</div>
 
 							<!-- 날짜 구간 -->
 							<div class="col-12 col-md-6">
 								<label for="from" class="form-label">시작 날짜</label> <input
-									type="date" name="from" value="${pageRequestDTO.from}" class="form-control">
+									type="date" name="from" value="${pageRequestDTO.from}"
+									class="form-control">
 							</div>
 							<div class="col-12 col-md-6">
 								<label for="to" class="form-label">종료 날짜</label> <input
-									type="date" name="to" value="${pageRequestDTO.to}" class="form-control">
+									type="date" name="to" value="${pageRequestDTO.to}"
+									class="form-control">
 							</div>
 
 							<!-- 버튼 -->
 							<div class="col-12">
 								<div class="d-flex justify-content-end gap-2">
-									<button class="btn btn-outline-secondary" type="reset">Clear</button>
+									<button class="btn btn-outline-secondary clearBtn" type="reset">Clear</button>
 									<button class="btn btn-primary" type="submit">Search</button>
 								</div>
 							</div>
@@ -170,23 +172,6 @@
 								</ul>
 							</nav>
 						</div>
-						<script>
-							document.querySelector(".pagination").addEventListener("click",function(e){
-								e.preventDefault()
-								e.stopPropagation()
-								
-								const target = e.target
-								
-								// 클릭된 요소가 a태그가 아니면 리턴
-								if(target.tagName !== 'A') {
-									return
-								}
-								
-								const num = target.getAttribute("data-num")
-								
-								self.location=`/todo/list?page=\${num}` //jsp의 el ${num}과 구분하기 위해 \붙여줌
-							},false)
-						</script>
 					</div>
 				</div>
 			</div>
@@ -203,5 +188,30 @@
 		src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.5/dist/js/bootstrap.bundle.min.js"
 		integrity="sha384-k6d4wzSIapyDyv1kpU366/PK5hCdSbCRGRCMv+eplOQJWyd1fbcAu9OCUj5zNLiq"
 		crossorigin="anonymous"></script>
+	<script>
+		document.querySelector(".pagination").addEventListener("click",function(e){
+			e.preventDefault()
+			e.stopPropagation()
+			
+			const target = e.target
+			
+			// 클릭된 요소가 a태그가 아니면 리턴
+			if(target.tagName !== 'A') {
+				return
+			}
+			
+			const num = target.getAttribute("data-num")
+			
+			self.location=`/todo/list?page=\${num}&${pageRequestDTO.link}` //jsp의 el ${num}과 구분하기 위해 \붙여줌
+		},false)
+		
+		// 검색 조건 초기화
+		document.querySelector(".clearBtn").addEventListener("click",function(e){
+			e.preventDefault()
+			e.stopPropagation()
+			
+			self.location = '/todo/list'
+		},false)
+	</script>
 </body>
 </html>

--- a/src/main/webapp/WEB-INF/views/todo/list.jsp
+++ b/src/main/webapp/WEB-INF/views/todo/list.jsp
@@ -1,4 +1,5 @@
-<%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
+<%@ page language="java" contentType="text/html; charset=UTF-8"
+	pageEncoding="UTF-8"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core"%>
 
 <!doctype html>
@@ -7,8 +8,11 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Bootstrap demo</title>
-<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.5/dist/css/bootstrap.min.css" rel="stylesheet"
-	integrity="sha384-SgOJa3DmI69IUzQ2PVdRZhwQ+dy64/BUtbMJw1MZ8t5HZApcHrRKUc4W0kG879m7" crossorigin="anonymous">
+<link
+	href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.5/dist/css/bootstrap.min.css"
+	rel="stylesheet"
+	integrity="sha384-SgOJa3DmI69IUzQ2PVdRZhwQ+dy64/BUtbMJw1MZ8t5HZApcHrRKUc4W0kG879m7"
+	crossorigin="anonymous">
 </head>
 <body>
 	<div class="container-fluid">
@@ -17,20 +21,87 @@
 				<nav class="navbar navbar-expand-lg bg-body-tertiary">
 					<div class="container-fluid">
 						<a class="navbar-brand" href="#">Navbar</a>
-						<button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav"
-							aria-expanded="false" aria-label="Toggle navigation">
+						<button class="navbar-toggler" type="button"
+							data-bs-toggle="collapse" data-bs-target="#navbarNav"
+							aria-controls="navbarNav" aria-expanded="false"
+							aria-label="Toggle navigation">
 							<span class="navbar-toggler-icon"></span>
 						</button>
 						<div class="collapse navbar-collapse" id="navbarNav">
 							<ul class="navbar-nav">
-								<li class="nav-item"><a class="nav-link active" aria-current="page" href="#">Home</a></li>
+								<li class="nav-item"><a class="nav-link active"
+									aria-current="page" href="#">Home</a></li>
 								<li class="nav-item"><a class="nav-link" href="#">Features</a></li>
 								<li class="nav-item"><a class="nav-link" href="#">Pricing</a></li>
-								<li class="nav-item"><a class="nav-link disabled" aria-disabled="true">Disabled</a></li>
+								<li class="nav-item"><a class="nav-link disabled"
+									aria-disabled="true">Disabled</a></li>
 							</ul>
 						</div>
 					</div>
 				</nav>
+			</div>
+		</div>
+		<div class="row content">
+			<div class="col">
+				<div class="card">
+					<div class="card-header">
+						<h5 class="mb-0">Search</h5>
+					</div>
+
+					<div class="card-body">
+						<form action="/todo/list" method="get" class="row g-3">
+
+							<!-- 완료 여부 -->
+							<div class="col-12">
+								<div class="form-check form-switch">
+									<input class="form-check-input" type="checkbox"
+										name="finished" value="true" checked}><label
+										class="form-check-label" for="finished"> 완료여부</label>
+								</div>
+							</div>
+
+							<!-- 검색 타입 & 키워드 -->
+							<div class="col-12 col-md-6">
+								<label class="form-label d-block mb-2">검색 대상</label>
+								<div class="form-check form-check-inline">
+									<input class="form-check-input" type="checkbox"
+										name="types" value="t"> <label
+										class="form-check-label" for="typeTitle">제목</label>
+								</div>
+								<div class="form-check form-check-inline">
+									<input class="form-check-input" type="checkbox"
+										name="types" value="w"> <label
+										class="form-check-label" for="typeWriter">작성자</label>
+								</div>
+							</div>
+
+							<div class="col-12 col-md-6">
+								<label for="keyword" class="form-label">키워드</label> <input
+									type="text" name="keyword" class="form-control"
+									placeholder="검색어를 입력하세요">
+							</div>
+
+							<!-- 날짜 구간 -->
+							<div class="col-12 col-md-6">
+								<label for="from" class="form-label">시작 날짜</label> <input
+									type="date" name="from" class="form-control">
+							</div>
+							<div class="col-12 col-md-6">
+								<label for="to" class="form-label">종료 날짜</label> <input
+									type="date" name="to" class="form-control">
+							</div>
+
+							<!-- 버튼 -->
+							<div class="col-12">
+								<div class="d-flex justify-content-end gap-2">
+									<button class="btn btn-outline-secondary" type="reset">Clear</button>
+									<button class="btn btn-primary" type="submit">Search</button>
+								</div>
+							</div>
+
+						</form>
+					</div>
+				</div>
 			</div>
 		</div>
 		<div class="row content">
@@ -59,7 +130,9 @@
 								<c:forEach items="${responseDTO.dtoList}" var="dto">
 									<tr>
 										<th scope="row"><c:out value="${dto.tno}" /></th>
-										<td><a href="/todo/read?tno=${dto.tno}&${pageRequestDTO.link}" class=""><c:out value="${dto.title}" /></a></td>
+										<td><a
+											href="/todo/read?tno=${dto.tno}&${pageRequestDTO.link}"
+											class=""><c:out value="${dto.title}" /></a></td>
 										<td><c:out value="${dto.writer}" /></td>
 										<td><c:out value="${dto.dueDate}" /></td>
 										<td><c:out value="${dto.finished}" /></td>
@@ -73,15 +146,20 @@
 								<ul class="pagination flex-wrap">
 									<!-- 이전 페이지 버튼 : 이전 페이지 없으면 비활성화 -->
 									<c:if test="${responseDTO.prev}">
-										<li class="page-item"><a class="page-link" data-num="${responseDTO.start-1}">Previous</a></li>
+										<li class="page-item"><a class="page-link"
+											data-num="${responseDTO.start-1}">Previous</a></li>
 									</c:if>
 									<!-- 페이지 넘버 : 현재 페이지 active -->
-									<c:forEach begin="${responseDTO.start}" end="${responseDTO.end}" var="num">
-										<li class="page-item ${responseDTO.page == num ? 'active':'' }"><a class="page-link" data-num="${num}">${num}</a></li>
+									<c:forEach begin="${responseDTO.start}"
+										end="${responseDTO.end}" var="num">
+										<li
+											class="page-item ${responseDTO.page == num ? 'active':'' }"><a
+											class="page-link" data-num="${num}">${num}</a></li>
 									</c:forEach>
 									<!-- 다음 페이지 버튼 : 다음 페이지 없으면 비활성화-->
 									<c:if test="${responseDTO.next}">
-										<li class="page-item"><a class="page-link" data-num="${responseDTO.end+1}">Next</a></li>
+										<li class="page-item"><a class="page-link"
+											data-num="${responseDTO.end+1}">Next</a></li>
 									</c:if>
 								</ul>
 							</nav>
@@ -115,7 +193,9 @@
 			</div>
 		</div>
 	</div>
-	<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.5/dist/js/bootstrap.bundle.min.js"
-		integrity="sha384-k6d4wzSIapyDyv1kpU366/PK5hCdSbCRGRCMv+eplOQJWyd1fbcAu9OCUj5zNLiq" crossorigin="anonymous"></script>
+	<script
+		src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.5/dist/js/bootstrap.bundle.min.js"
+		integrity="sha384-k6d4wzSIapyDyv1kpU366/PK5hCdSbCRGRCMv+eplOQJWyd1fbcAu9OCUj5zNLiq"
+		crossorigin="anonymous"></script>
 </body>
 </html>

--- a/src/main/webapp/WEB-INF/views/todo/list.jsp
+++ b/src/main/webapp/WEB-INF/views/todo/list.jsp
@@ -41,6 +41,12 @@
 				</nav>
 			</div>
 		</div>
+<!-- 모든 파라미터 출력 -->
+<!-- 
+<c:forEach var="p" items="${paramValues}">
+    <p>${p.key} = ${p.value[0]}</p>
+</c:forEach>
+ -->
 		<div class="row content">
 			<div class="col">
 				<div class="card">
@@ -55,40 +61,44 @@
 							<div class="col-12">
 								<div class="form-check form-switch">
 									<input class="form-check-input" type="checkbox"
-										name="finished" value="true" checked}><label
+										name="finished" value="true" ${param.finished ? 'checked' : ''}><label
 										class="form-check-label" for="finished"> 완료여부</label>
 								</div>
 							</div>
 
 							<!-- 검색 타입 & 키워드 -->
+							<c:forEach var="val" items="${paramValues.types}">
+								<c:if test="${val == 't'}"><c:set var="titleChecked" value="checked"/></c:if>
+								<c:if test="${val == 'w'}"><c:set var="writerChecked" value="checked"/></c:if>
+							</c:forEach>
 							<div class="col-12 col-md-6">
 								<label class="form-label d-block mb-2">검색 대상</label>
 								<div class="form-check form-check-inline">
 									<input class="form-check-input" type="checkbox"
-										name="types" value="t"> <label
+										name="types" value="t" ${titleChecked} > <label
 										class="form-check-label" for="typeTitle">제목</label>
 								</div>
 								<div class="form-check form-check-inline">
 									<input class="form-check-input" type="checkbox"
-										name="types" value="w"> <label
+										name="types" value="w" ${writerChecked}> <label
 										class="form-check-label" for="typeWriter">작성자</label>
 								</div>
 							</div>
 
 							<div class="col-12 col-md-6">
 								<label for="keyword" class="form-label">키워드</label> <input
-									type="text" name="keyword" class="form-control"
+									type="text" name="keyword" value="${param.keyword}" class="form-control"
 									placeholder="검색어를 입력하세요">
 							</div>
 
 							<!-- 날짜 구간 -->
 							<div class="col-12 col-md-6">
 								<label for="from" class="form-label">시작 날짜</label> <input
-									type="date" name="from" class="form-control">
+									type="date" name="from" value="${param.from}" class="form-control">
 							</div>
 							<div class="col-12 col-md-6">
 								<label for="to" class="form-label">종료 날짜</label> <input
-									type="date" name="to" class="form-control">
+									type="date" name="to" value="${param.to}" class="form-control">
 							</div>
 
 							<!-- 버튼 -->

--- a/src/test/java/org/zerock/springex/mapper/TodoMapperTests.java
+++ b/src/test/java/org/zerock/springex/mapper/TodoMapperTests.java
@@ -60,7 +60,10 @@ public class TodoMapperTests {
 				.page(3)
 				.size(10)
 				.types(new String[]{"t","w"})
-				.keyword("aaa")
+				.keyword("dy")
+				.finished(false)
+				.from(LocalDate.parse("2025-06-01"))
+				.to(LocalDate.parse("2025-06-30"))
 				.build();
 		
 		List<TodoVO> voLIst = todoMapper.selectList(pageRequestDTO);

--- a/src/test/java/org/zerock/springex/mapper/TodoMapperTests.java
+++ b/src/test/java/org/zerock/springex/mapper/TodoMapperTests.java
@@ -59,15 +59,30 @@ public class TodoMapperTests {
 		PageRequestDTO pageRequestDTO = PageRequestDTO.builder()
 				.page(3)
 				.size(10)
-				.types(new String[]{"t","w"})
-				.keyword("dy")
-				.finished(false)
-				.from(LocalDate.parse("2025-06-01"))
-				.to(LocalDate.parse("2025-06-30"))
 				.build();
 		
 		List<TodoVO> voLIst = todoMapper.selectList(pageRequestDTO);
 		
 		voLIst.forEach(todo -> log.info(todo));
+	}
+	
+	@Test
+	public void testSelectSearch() {
+		PageRequestDTO pageRequestDTO = PageRequestDTO.builder()
+				.page(3)
+				.size(10)
+				.types(new String[]{"t","w"})
+				.keyword("dy")
+				.finished(false)
+				.from(LocalDate.of(2025,1,1))
+				.to(LocalDate.of(2025,9,29))
+				.build();
+		
+		List<TodoVO> voList = todoMapper.selectList(pageRequestDTO);
+		
+		voList.forEach(vo -> log.info(vo));
+		
+		log.info(todoMapper.getCount(pageRequestDTO));
+		
 	}
 }

--- a/src/test/java/org/zerock/springex/mapper/TodoMapperTests.java
+++ b/src/test/java/org/zerock/springex/mapper/TodoMapperTests.java
@@ -59,6 +59,8 @@ public class TodoMapperTests {
 		PageRequestDTO pageRequestDTO = PageRequestDTO.builder()
 				.page(3)
 				.size(10)
+				.types(new String[]{"t","w"})
+				.keyword("aaa")
 				.build();
 		
 		List<TodoVO> voLIst = todoMapper.selectList(pageRequestDTO);


### PR DESCRIPTION
## 현재 상태 (진행 중)
- [x] DTO에 검색 관련 필드(`keyword`) 추가
- [x] mapper.xml WHERE절에 제목(title), 작성자(writer) LIKE 검색 조건 추가
- [x] Service/Controller 연동
- [x] 단위 테스트 코드 작성
- [x] 추가 필터(finished, from/to 기간) 기능 구현
- [x] 검색/필터링 ui 화면 추가
- [x] 검색/필터링 검색 후 값 유지
- [ ] 페이지 이동 시 페이지 링크에 검색 값 항상 유지(RequestDTO-getLink())

## 현재까지 구현된 부분
- 검색어(keyword) 입력 시 제목·작성자 부분 일치 조건 적용(mapper 수정)
- 각 검색 값 없을 경우 리스트 조회 동작 확인 완료
- 리스트 페이지 검색 기능 추가 및 테스트 완료

## TODO (남은 작업)
- [ ] 페이지 이동 시 검색 값 유지
- [ ] 예외 처리 및 Validation 로직 강화
- [ ] 테스트 케이스 보강

## 테스트 방법 (임시)
1. 키워드 없는 요청 → 전체 목록 반환 확인
2. 키워드 입력 시 제목/작성자 LIKE 검색 결과 확인

## 비고
- 본 PR은 Draft 상태이며 기능 완성 전까지 커밋/설명 계속 추가 예정
- 최종 완료 후 리뷰 요청 예정

## 관련 이슈
Closes #1 